### PR TITLE
fix deprecated mojo method name

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Mojolicious-Plugin-ServerStatus
 
+0.05    2024-10-16
+    - fix deprecated mojo method name
+
 0.04    2016-03-18
     - updating status when request finish
     - add userinfo

--- a/lib/Mojolicious/Plugin/ServerStatus.pm
+++ b/lib/Mojolicious/Plugin/ServerStatus.pm
@@ -7,7 +7,7 @@ use JSON;
 use Fcntl qw(:DEFAULT :flock);
 use IO::Handle;
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 my $JSON = JSON->new->utf8(0);
 
@@ -64,7 +64,7 @@ sub register {
     }
 
     my $r = $app->routes;
-    $r->route($args->{path})->to(
+    $r->any($args->{path})->to(
         cb => sub {
             my $self = shift;
             my $req = $self->req;


### PR DESCRIPTION
Mojolicious::Routes::Route::route is DEPRECATED in favor of Mojolicious::Routes::Route::any

With this change the module becomes compatible with current Mojolicious framework.